### PR TITLE
Pin rake to under v11.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "http://rubygems.org"
 gemspec
 
 gem 'unf'
+gem 'rake', '< 11.0'
 
 # if File.exist?(File.expand_path("../../vagrant-spec", __FILE__))
 #   gem 'vagrant-spec', path: "../vagrant-spec"


### PR DESCRIPTION
## WHAT
Pin rake to under v11.0

## WHY
To fix following error:

```
NoMethodError: undefined method `last_comment' for #<Rake::Application:0x00000000ff9f88>
```

Since Rake 11.0.1 removes the last_comment method which other gem uses,
to avoid to get the error we have to pin rake's version.

from: https://github.com/increments/increments-cookbook/pull/264

cc @yuku-t 